### PR TITLE
feat: implement stream api

### DIFF
--- a/internal/grpc/client/manager.go
+++ b/internal/grpc/client/manager.go
@@ -77,7 +77,7 @@ func (m *Manager) StreamTaskOutput(ctx context.Context, taskID string) error {
 
 	for {
 		resp, err := stream.Recv()
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			// Stream completed normally
 			return nil
 		}

--- a/internal/grpc/client/manager.go
+++ b/internal/grpc/client/manager.go
@@ -82,13 +82,13 @@ func (m *Manager) StreamTaskOutput(ctx context.Context, taskID string) error {
 			return nil
 		}
 		if err != nil {
-			return fmt.Errorf("error receiving from stream: %w", err)
+			return fmt.Errorf("error receiving stream: %w", err)
 		}
 
-        // Write raw bytes to stdout without UTF-8 conversion
-        if _, err := os.Stdout.Write(resp.Output); err != nil {
-            return fmt.Errorf("error writing to stdout: %w", err)
-        }
+		// Write raw bytes to stdout without UTF-8 conversion
+		if _, err := os.Stdout.Write(resp.Output); err != nil {
+			return fmt.Errorf("error writing to stdout: %w", err)
+		}
 	}
 }
 

--- a/internal/grpc/client/manager.go
+++ b/internal/grpc/client/manager.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"

--- a/internal/grpc/server/server.go
+++ b/internal/grpc/server/server.go
@@ -101,6 +101,8 @@ func (s *Server) Shutdown() {
 		close(done)
 	}()
 
+	// give the ongoing RPCs a chance to complete
+	// TODO: make this timeout configurable
 	select {
 	case <-done:
 		log.Println("gRPC server stopped gracefully.")

--- a/internal/grpc/server/server.go
+++ b/internal/grpc/server/server.go
@@ -106,7 +106,7 @@ func (s *Server) Shutdown() {
 	select {
 	case <-done:
 		log.Println("gRPC server stopped gracefully.")
-	case <-time.After(10 * time.Second):
+	case <-time.After(30 * time.Second):
 		log.Println("GracefulStop timed out; forcing shutdown.")
 		s.grpcServer.Stop()
 	}

--- a/internal/grpc/server/server.go
+++ b/internal/grpc/server/server.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"net"
+	"time"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
@@ -92,14 +93,24 @@ func (s *Server) Addr() string {
 // Shutdown shuts down the gRPC server and waits for all tasks to complete
 func (s *Server) Shutdown() {
 	log.Println("Shutting down gRPC server...")
-	// TODO: GracefulStop() waits for all RPCs to complete
-	// we should add a timeout to the graceful stop
-	// for now the supported RPCs are all quick to return so we should be fine
-	s.grpcServer.GracefulStop()
+
+	// GracefulStop with timeout
+	done := make(chan struct{})
+	go func() {
+		s.grpcServer.GracefulStop()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		log.Println("gRPC server stopped gracefully.")
+	case <-time.After(10 * time.Second):
+		log.Println("GracefulStop timed out; forcing shutdown.")
+		s.grpcServer.Stop()
+	}
 
 	log.Println("Waiting for all tasks to complete...")
-	err := s.taskServer.taskManager.WaitForTasks()
-	if err != nil {
+	if err := s.taskServer.taskManager.WaitForTasks(); err != nil {
 		log.Printf("Error waiting for tasks to complete: %v", err)
 	}
 }

--- a/internal/grpc/server/task_manager.go
+++ b/internal/grpc/server/task_manager.go
@@ -101,7 +101,7 @@ func (s *taskManagerServer) StreamTaskOutput(req *pb.StreamTaskOutputRequest, st
 		return err
 	}
 
-	// Create a writer closure that sends data over the gRPC stream
+	// Create a writer that sends data over the gRPC stream
 	// stream.Send() will block if the client is slow to read the data
 	writer := func(data []byte) error {
 		return stream.Send(&pb.StreamTaskOutputResponse{Output: data})

--- a/internal/grpc/server/task_manager.go
+++ b/internal/grpc/server/task_manager.go
@@ -89,7 +89,22 @@ func checkAuthorization(caller string, taskObj *taskmanager.Task) error {
 	return nil
 }
 
-// StreamTaskOutput
+// StreamTaskOutput outputs the task’s streams to the client by tracking its read offset.
 func (s *taskManagerServer) StreamTaskOutput(req *pb.StreamTaskOutputRequest, stream pb.TaskManager_StreamTaskOutputServer) error {
-	return status.Errorf(codes.Unimplemented, "StreamTaskOutput not implemented")
+	taskObj, err := s.taskManager.GetTask(stream.Context(), req.TaskId)
+	if err != nil {
+		return task.TaskErrorToGRPC(err)
+	}
+
+	caller := stream.Context().Value(basegrpc.ClientIDKey).(string)
+	if err = checkAuthorization(caller, taskObj); err != nil {
+		return err
+	}
+
+	// Create a writer closure that sends data over the gRPC stream
+	writer := func(data []byte) error {
+		return stream.Send(&pb.StreamTaskOutputResponse{Output: data})
+	}
+
+	return s.taskManager.StreamTaskOutput(stream.Context(), req.TaskId, writer)
 }

--- a/internal/grpc/server/task_manager.go
+++ b/internal/grpc/server/task_manager.go
@@ -110,7 +110,11 @@ func (s *taskManagerServer) StreamTaskOutput(req *pb.StreamTaskOutputRequest, st
 	if err != nil {
 		return task.TaskErrorToGRPC(err)
 	}
-	context.AfterFunc(stream.Context(), func() { jobStreamer.Close() })
+	context.AfterFunc(stream.Context(), func() {
+		if err := jobStreamer.Close(); err != nil {
+			log.Printf("Failed to close job streamer: %v", err)
+		}
+	})
 
 	buf := make([]byte, 4096)
 

--- a/internal/grpc/server/task_manager.go
+++ b/internal/grpc/server/task_manager.go
@@ -102,9 +102,15 @@ func (s *taskManagerServer) StreamTaskOutput(req *pb.StreamTaskOutputRequest, st
 	}
 
 	// Create a writer closure that sends data over the gRPC stream
+	// stream.Send() will block if the client is slow to read the data
 	writer := func(data []byte) error {
 		return stream.Send(&pb.StreamTaskOutputResponse{Output: data})
 	}
 
-	return s.taskManager.StreamTaskOutput(stream.Context(), req.TaskId, writer)
+	err = s.taskManager.StreamTaskOutput(stream.Context(), req.TaskId, writer)
+	if err != nil {
+		return task.TaskErrorToGRPC(err)
+	}
+
+	return nil
 }

--- a/internal/task/error.go
+++ b/internal/task/error.go
@@ -22,6 +22,8 @@ const (
 	ErrFailedPrecondition
 	// ErrInternal indicates an internal system error
 	ErrInternal
+	// ErrNotAvailable indicates that the requested resource is not available
+	ErrNotAvailable
 )
 
 // TaskError represents an error that occurred during task management
@@ -75,6 +77,8 @@ func TaskErrorToGRPC(err error) error {
 			code = codes.FailedPrecondition
 		case ErrInternal:
 			code = codes.Internal
+		case ErrNotAvailable:
+			code = codes.Unavailable
 		default:
 			code = codes.Internal
 		}

--- a/internal/task/error.go
+++ b/internal/task/error.go
@@ -24,6 +24,8 @@ const (
 	ErrInternal
 	// ErrNotAvailable indicates that the requested resource is not available
 	ErrNotAvailable
+	// ErrCanceled indicates that the task was canceled
+	ErrCanceled
 )
 
 // TaskError represents an error that occurred during task management
@@ -79,6 +81,8 @@ func TaskErrorToGRPC(err error) error {
 			code = codes.Internal
 		case ErrNotAvailable:
 			code = codes.Unavailable
+		case ErrCanceled:
+			code = codes.Canceled
 		default:
 			code = codes.Internal
 		}

--- a/internal/task/manager/manager.go
+++ b/internal/task/manager/manager.go
@@ -31,6 +31,7 @@ func (tm *TaskManager) addTask(task *Task) {
 }
 
 // WaitForTasks waits for all tasks to complete with a timeout
+// TODO: make this timeout configurable
 func (tm *TaskManager) WaitForTasks() error {
 	tm.mu.RLock()
 	tasks := make([]*Task, 0, len(tm.tasksMapByID))
@@ -66,6 +67,7 @@ func (tm *TaskManager) WaitForTasks() error {
 	}
 }
 
+// getTaskFromMap gets a task from the task map by task ID
 func (tm *TaskManager) getTaskFromMap(taskID string) (*Task, error) {
 	tm.mu.RLock()
 	defer tm.mu.RUnlock()

--- a/internal/task/manager/monitor.go
+++ b/internal/task/manager/monitor.go
@@ -99,6 +99,8 @@ func (tm *TaskManager) monitorProcess(taskID string, cmd *exec.Cmd) {
 		log.Printf("Failed to clean up cgroup after process completion: %v", cleanupErr)
 	}
 
+	task.GetWriter().Close()
+
 	// Signal that this task is done
 	close(task.done)
 

--- a/internal/task/manager/monitor.go
+++ b/internal/task/manager/monitor.go
@@ -99,7 +99,7 @@ func (tm *TaskManager) monitorProcess(taskID string, cmd *exec.Cmd) {
 		log.Printf("Failed to clean up cgroup after process completion: %v", cleanupErr)
 	}
 
-	task.GetWriter().Close()
+	task.closeWriter()
 
 	// Signal that this task is done
 	close(task.done)

--- a/internal/task/manager/monitor.go
+++ b/internal/task/manager/monitor.go
@@ -88,7 +88,7 @@ func (tm *TaskManager) monitorProcess(taskID string, cmd *exec.Cmd) {
 			}
 		} else {
 			task.SetStatus(basetask.JobStatusSignaled)
-			if task.GetTerminationSignal() == "" {
+			if task.GetTerminationSource() == "" {
 				task.SetTerminationSource("system")
 			}
 		}

--- a/internal/task/manager/start.go
+++ b/internal/task/manager/start.go
@@ -51,6 +51,12 @@ func (tm *TaskManager) StartTask(ctx context.Context, command string, args []str
 		CgroupFD:    int(cgroupFd.Fd()),
 	}
 
+	writer := NewTaskWriter()
+	// Set up output capture
+	cmd.Stdout = writer
+	cmd.Stderr = writer
+	
+
 	// Start the process
 	if err := cmd.Start(); err != nil {
 		// clean up the cgroup so it doesn't leak
@@ -79,7 +85,7 @@ func (tm *TaskManager) StartTask(ctx context.Context, command string, args []str
 	cgroupFd.Close()
 
 	// Create the new task and add it to the task manager
-	task := CreateNewTask(taskID, clientID.(string), pgid, startTime)
+	task := CreateNewTask(taskID, clientID.(string), pgid, startTime, writer)
 	tm.addTask(task)
 
 	// Start monitoring the process

--- a/internal/task/manager/start.go
+++ b/internal/task/manager/start.go
@@ -52,7 +52,7 @@ func (tm *TaskManager) StartTask(ctx context.Context, command string, args []str
 	}
 
 	writer := NewTaskWriter()
-	// Set up output capture
+	// Set up output capture; we use a single writer for both stdout and stderr
 	cmd.Stdout = writer
 	cmd.Stderr = writer
 	

--- a/internal/task/manager/start.go
+++ b/internal/task/manager/start.go
@@ -55,7 +55,6 @@ func (tm *TaskManager) StartTask(ctx context.Context, command string, args []str
 	// Set up output capture; we use a single writer for both stdout and stderr
 	cmd.Stdout = writer
 	cmd.Stderr = writer
-	
 
 	// Start the process
 	if err := cmd.Start(); err != nil {

--- a/internal/task/manager/stream.go
+++ b/internal/task/manager/stream.go
@@ -1,0 +1,64 @@
+package task
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log"
+
+	basetask "github.com/mikewurtz/taskman/internal/task"
+)
+
+func mergeContexts(a, b context.Context) (context.Context, context.CancelFunc) {
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		select {
+		case <-a.Done():
+		case <-b.Done():
+		}
+		cancel()
+	}()
+	return ctx, cancel
+}
+
+// StreamTaskOutput streams the output of a task to the provided writer function.
+// The writer function is called with chunks of output data. Returns when the task is complete or an error occurs.
+func (tm *TaskManager) StreamTaskOutput(ctx context.Context, taskID string, writer func([]byte) error) error {
+	taskObj, err := tm.getTaskFromMap(taskID)
+	if err != nil {
+		return err
+	}
+
+	// Merge client and server contexts to cancel when either is done
+	// if the server context is cancelled, we want to stop the stream
+	mergedCtx, cancel := mergeContexts(ctx, tm.ctx)
+	defer cancel()
+
+	var offset int64
+	for {
+		data, newOffset, err := taskObj.ReadOutput(mergedCtx, offset)
+		if err == io.EOF {
+			return nil
+		}
+		if err != nil {
+			if mergedCtx.Err() != nil {
+				switch {
+				case tm.ctx.Err() != nil:
+					log.Printf("Task manager server context canceled: %v", tm.ctx.Err())
+					return basetask.NewTaskError(basetask.ErrNotAvailable, "server shutting down")
+				default:
+					log.Printf("Merged context canceled: %v", mergedCtx.Err())
+				}
+			}
+			return fmt.Errorf("failed to read output: %w", err)
+		}
+
+		if len(data) > 0 {
+			if err := writer(data); err != nil {
+				return fmt.Errorf("failed to write output: %w", err)
+			}
+		}
+
+		offset = newOffset
+	}
+}

--- a/internal/task/manager/stream.go
+++ b/internal/task/manager/stream.go
@@ -2,7 +2,6 @@ package task
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"log"
 
@@ -47,15 +46,17 @@ func (tm *TaskManager) StreamTaskOutput(ctx context.Context, taskID string, writ
 					log.Printf("Task manager server context canceled: %v", tm.ctx.Err())
 					return basetask.NewTaskError(basetask.ErrNotAvailable, "server shutting down")
 				default:
-					log.Printf("Merged context canceled: %v", mergedCtx.Err())
+					log.Printf("Client context canceled: %v", mergedCtx.Err())
+					return basetask.NewTaskError(basetask.ErrCanceled, "client canceled stream")
 				}
 			}
-			return fmt.Errorf("failed to read output: %w", err)
+			return basetask.NewTaskError(basetask.ErrInternal, "failed to read output")
 		}
 
 		if len(data) > 0 {
+			// write the data to the provided writer function
 			if err := writer(data); err != nil {
-				return fmt.Errorf("failed to write output: %w", err)
+				return basetask.NewTaskError(basetask.ErrInternal, "failed to write output")
 			}
 		}
 

--- a/internal/task/manager/stream.go
+++ b/internal/task/manager/stream.go
@@ -37,7 +37,7 @@ func (tm *TaskManager) StreamTaskOutput(ctx context.Context, taskID string, writ
 	var offset int64
 	for {
 		data, newOffset, err := taskObj.ReadOutput(mergedCtx, offset)
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			// we hit end of the output stream; return nil to indicate success
 			return nil
 		}

--- a/internal/task/manager/stream.go
+++ b/internal/task/manager/stream.go
@@ -2,6 +2,7 @@ package task
 
 import (
 	"context"
+	"errors"
 	"io"
 	"log"
 

--- a/internal/task/manager/task.go
+++ b/internal/task/manager/task.go
@@ -55,11 +55,11 @@ func CreateNewTask(id, clientID string, pid int, startTime time.Time, writer *Ta
 	return t
 }
 
-func (t *Task) GetWriter() *TaskWriter {
-	t.mu.RLock()
-	defer t.mu.RUnlock()
-	return t.writer
+// closeWriter closes the writer for the task
+func (t *Task) closeWriter() {
+	t.writer.Close()
 }
+
 
 // Update ReadOutput to delegate to TaskWriter
 func (t *Task) ReadOutput(ctx context.Context, offset int64) ([]byte, int64, error) {

--- a/internal/task/manager/task.go
+++ b/internal/task/manager/task.go
@@ -41,9 +41,9 @@ type TaskSnapshot struct {
 	TerminationSource string
 }
 
-// NewTask creates a new task
+// CreateNewTask creates a new task with a writer
 func CreateNewTask(id, clientID string, pid int, startTime time.Time, writer *TaskWriter) *Task {
-	t := &Task{
+	return &Task{
 		id:        id,
 		clientID:  clientID,
 		processID: pid,
@@ -52,7 +52,6 @@ func CreateNewTask(id, clientID string, pid int, startTime time.Time, writer *Ta
 		done:      make(chan struct{}),
 		writer:    writer,
 	}
-	return t
 }
 
 // closeWriter closes the writer for the task
@@ -61,7 +60,7 @@ func (t *Task) closeWriter() {
 }
 
 
-// Update ReadOutput to delegate to TaskWriter
+// ReadOutput delegates to TaskWriter
 func (t *Task) ReadOutput(ctx context.Context, offset int64) ([]byte, int64, error) {
     return t.writer.ReadOutput(ctx, offset)
 }

--- a/internal/task/manager/task.go
+++ b/internal/task/manager/task.go
@@ -1,6 +1,7 @@
 package task
 
 import (
+	"context"
 	"sync"
 	"time"
 
@@ -22,6 +23,8 @@ type Task struct {
 	terminationSource string
 	endTime           time.Time
 	done              chan struct{}
+
+	writer *TaskWriter
 }
 
 // TaskSnapshot is a snapshot of the task's state
@@ -39,15 +42,28 @@ type TaskSnapshot struct {
 }
 
 // NewTask creates a new task
-func CreateNewTask(id, clientID string, pid int, startTime time.Time) *Task {
-	return &Task{
+func CreateNewTask(id, clientID string, pid int, startTime time.Time, writer *TaskWriter) *Task {
+	t := &Task{
 		id:        id,
 		clientID:  clientID,
 		processID: pid,
 		startTime: startTime,
 		status:    basetask.JobStatusStarted,
 		done:      make(chan struct{}),
+		writer:    writer,
 	}
+	return t
+}
+
+func (t *Task) GetWriter() *TaskWriter {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return t.writer
+}
+
+// Update ReadOutput to delegate to TaskWriter
+func (t *Task) ReadOutput(ctx context.Context, offset int64) ([]byte, int64, error) {
+    return t.writer.ReadOutput(ctx, offset)
 }
 
 // GetID returns the task ID

--- a/internal/task/manager/task.go
+++ b/internal/task/manager/task.go
@@ -1,7 +1,6 @@
 package task
 
 import (
-	"context"
 	"sync"
 	"time"
 
@@ -57,11 +56,6 @@ func CreateNewTask(id, clientID string, pid int, startTime time.Time, writer *Ta
 // closeWriter closes the writer for the task
 func (t *Task) closeWriter() {
 	t.writer.Close()
-}
-
-// ReadOutput delegates to TaskWriter
-func (t *Task) ReadOutput(ctx context.Context, offset int64) ([]byte, int64, error) {
-	return t.writer.ReadOutput(ctx, offset)
 }
 
 // GetID returns the task ID

--- a/internal/task/manager/task.go
+++ b/internal/task/manager/task.go
@@ -59,10 +59,9 @@ func (t *Task) closeWriter() {
 	t.writer.Close()
 }
 
-
 // ReadOutput delegates to TaskWriter
 func (t *Task) ReadOutput(ctx context.Context, offset int64) ([]byte, int64, error) {
-    return t.writer.ReadOutput(ctx, offset)
+	return t.writer.ReadOutput(ctx, offset)
 }
 
 // GetID returns the task ID

--- a/internal/task/manager/taskreader.go
+++ b/internal/task/manager/taskreader.go
@@ -1,0 +1,32 @@
+package task
+
+import (
+	"context"
+	"io"
+)
+
+// make sure TaskReader implements io.Reader
+var _ io.ReadCloser = &TaskReader{}
+
+// TaskReader reads the output of a task
+type TaskReader struct {
+	tw     *TaskWriter
+	ctx    context.Context
+	offset int64
+}
+
+// Read reads the output of the task
+func (tr *TaskReader) Read(p []byte) (int, error) {
+	data, nextOffset, err := tr.tw.ReadOutput(tr.ctx, tr.offset)
+	if err != nil {
+		return 0, err
+	}
+	n := copy(p, data)
+	tr.offset = nextOffset
+	return n, nil
+}
+
+func (tr *TaskReader) Close() error {
+	// No-op: the context governs cancellation
+	return nil
+}

--- a/internal/task/manager/taskreader.go
+++ b/internal/task/manager/taskreader.go
@@ -13,6 +13,7 @@ type TaskReader struct {
 	tw     *TaskWriter
 	ctx    context.Context
 	offset int64
+	cancel context.CancelFunc
 }
 
 // Read reads the output of the task
@@ -26,7 +27,10 @@ func (tr *TaskReader) Read(p []byte) (int, error) {
 	return n, nil
 }
 
+// Close should now cancel the underlying context to stop further reads.
 func (tr *TaskReader) Close() error {
-	// No-op: the context governs cancellation
+	if tr.cancel != nil {
+		tr.cancel()
+	}
 	return nil
 }

--- a/internal/task/manager/taskwriter.go
+++ b/internal/task/manager/taskwriter.go
@@ -3,82 +3,94 @@ package task
 import (
 	"context"
 	"io"
+	"slices"
 	"sync"
 )
 
+// make sure TaskWriter implements io.Writer
 var _ io.Writer = &TaskWriter{}
 
 // TaskWriter handles writing and buffering task output
 // Uses a single shared output buffer that is written to for the task
 // clients then read from this buffer with their own offsets
 type TaskWriter struct {
-	mu     sync.RWMutex
-	output []byte
+	// protects access to output buffer
+	outputMu sync.RWMutex
+	output   []byte
+
+	// protects condition variable
+	condMu sync.Mutex
 	cond   *sync.Cond
 	done   chan struct{}
-	io.Writer
 }
 
 // NewTaskWriter initializes a new TaskWriter
 func NewTaskWriter() *TaskWriter {
 	tw := &TaskWriter{
-        // initialize the output buffer with a default size
-        // this prevents us from allocating a new buffer on every write initially
 		output: make([]byte, 0, 4096),
 		done:   make(chan struct{}),
 	}
-	tw.cond = sync.NewCond(&tw.mu)
+	tw.cond = sync.NewCond(&tw.condMu)
 	return tw
 }
 
 // Write writes the output to the task writer
 // when we append to the buffer we broadcast to wake up any waiting readers
 func (tw *TaskWriter) Write(p []byte) (n int, err error) {
-	tw.mu.Lock()
-	defer tw.mu.Unlock()
+	tw.outputMu.Lock()
 	tw.output = append(tw.output, p...)
+	tw.outputMu.Unlock()
+
+	tw.condMu.Lock()
 	tw.cond.Broadcast()
+	tw.condMu.Unlock()
+
 	return len(p), nil
 }
 
-// Send up to 4KB of data to the client at a 
+// maxChunkSize is the maximum number of bytes to send to the client at a time
 // TODO: make this configurable
 const maxChunkSize = 4096
 
 // ReadOutput reads the output from the task writer. Will send up to maxChunkSize bytes to the client.
 func (tw *TaskWriter) ReadOutput(ctx context.Context, offset int64) ([]byte, int64, error) {
-    tw.mu.Lock()
-    defer tw.mu.Unlock()
+	for {
+		tw.outputMu.RLock()
+		if offset < int64(len(tw.output)) {
+			end := offset + maxChunkSize
+			if end > int64(len(tw.output)) {
+				end = int64(len(tw.output))
+			}
+            // return a clone of the data
+			data := slices.Clone(tw.output[offset:end])
+			tw.outputMu.RUnlock()
+			return data, end, nil
+		}
+		tw.outputMu.RUnlock()
 
-    for offset >= int64(len(tw.output)) {
-        select {
-        case <-ctx.Done():
-            // if the context is done, then return
-            return nil, offset, ctx.Err()
-        case <-tw.done:
-            // if the task is done and the offset is >= length of output,
-            // we are at the end of the output and should return EOF
-            if offset >= int64(len(tw.output)) {
-                return nil, offset, io.EOF
-            }
-        default:
-            // if we are caught up and the task is not done and the context is not done
-            // then wait for the task to write more data
-            tw.cond.Wait()
-        }
-    }
-
-    // Calculate the new offset by reading only up to maxChunkSize bytes
-    endOffset := offset + maxChunkSize
-    if endOffset > int64(len(tw.output)) {
-        endOffset = int64(len(tw.output))
-    }
-    return tw.output[offset:endOffset], endOffset, nil
+		select {
+		case <-ctx.Done():
+			return nil, offset, ctx.Err()
+		case <-tw.done:
+			tw.outputMu.RLock()
+			if offset >= int64(len(tw.output)) {
+				tw.outputMu.RUnlock()
+				return nil, offset, io.EOF
+			}
+			tw.outputMu.RUnlock()
+		default:
+			// wait for the condition variable to be signaled
+			tw.condMu.Lock()
+			tw.cond.Wait()
+			tw.condMu.Unlock()
+		}
+	}
 }
-
 
 // Close closes the task writer and wakes up any waiting readers
 func (tw *TaskWriter) Close() {
+	tw.condMu.Lock()
 	close(tw.done)
 	tw.cond.Broadcast()
+	tw.condMu.Unlock()
 }

--- a/internal/task/manager/taskwriter.go
+++ b/internal/task/manager/taskwriter.go
@@ -1,0 +1,73 @@
+package task
+
+import (
+	"context"
+	"io"
+	"sync"
+)
+
+var _ io.Writer = &TaskWriter{}
+
+// TaskWriter handles writing and buffering task output
+type TaskWriter struct {
+	mu     sync.RWMutex
+	output []byte
+	cond   *sync.Cond
+	done   chan struct{}
+	io.Writer
+}
+
+func NewTaskWriter() *TaskWriter {
+	tw := &TaskWriter{
+		output: make([]byte, 0, 4096),
+		done:   make(chan struct{}),
+	}
+	tw.cond = sync.NewCond(&tw.mu)
+	return tw
+}
+
+// Write writes the output to the task writer
+func (tw *TaskWriter) Write(p []byte) (n int, err error) {
+	tw.mu.Lock()
+	defer tw.mu.Unlock()
+	tw.output = append(tw.output, p...)
+	tw.cond.Broadcast()
+	return len(p), nil
+}
+
+// Send up to 4KB of data to the client at a 
+// TODO: make this configurable
+const maxChunkSize = 4096
+
+// ReadOutput reads the output from the task writer
+func (tw *TaskWriter) ReadOutput(ctx context.Context, offset int64) ([]byte, int64, error) {
+    tw.mu.Lock()
+    defer tw.mu.Unlock()
+
+    for offset >= int64(len(tw.output)) {
+        select {
+        case <-ctx.Done():
+            return nil, offset, ctx.Err()
+        case <-tw.done:
+            if offset >= int64(len(tw.output)) {
+                return nil, offset, io.EOF
+            }
+        default:
+            tw.cond.Wait()
+        }
+    }
+
+    // Calculate the new offset by reading only up to maxChunkSize bytes
+    endOffset := offset + maxChunkSize
+    if endOffset > int64(len(tw.output)) {
+        endOffset = int64(len(tw.output))
+    }
+    return tw.output[offset:endOffset], endOffset, nil
+}
+
+
+// Close closes the task writer and wakes up any waiting readers
+func (tw *TaskWriter) Close() {
+	close(tw.done)
+	tw.cond.Broadcast()
+}

--- a/tests/integration/auth_test.go
+++ b/tests/integration/auth_test.go
@@ -135,9 +135,9 @@ func TestIntegration_StartTaskTestAuthorization(t *testing.T) {
 	stream, err := client2.StreamTaskOutput(ctx, &pb.StreamTaskOutputRequest{
 		TaskId: resp.TaskId,
 	})
-	require.NoError(t, err) // Stream is successfully created
+	require.NoError(t, err)
 
-	_, err = stream.Recv() // Error occurs here due to failed authorization
+	_, err = stream.Recv()
 	require.Error(t, err)
 
 	sts, ok = status.FromError(err)

--- a/tests/integration/auth_test.go
+++ b/tests/integration/auth_test.go
@@ -131,6 +131,19 @@ func TestIntegration_StartTaskTestAuthorization(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, codes.NotFound, sts.Code())
 
+	// Try to stream the task output using a different client (unauthorized)
+	stream, err := client2.StreamTaskOutput(ctx, &pb.StreamTaskOutputRequest{
+		TaskId: resp.TaskId,
+	})
+	require.NoError(t, err) // Stream is successfully created
+
+	_, err = stream.Recv() // Error occurs here due to failed authorization
+	require.Error(t, err)
+
+	sts, ok = status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.NotFound, sts.Code())
+
 	// get the status of the task using the admin client
 	adminClient := createTestClient(t, "admin")
 	var adminStatusResp *pb.TaskStatusResponse
@@ -151,4 +164,5 @@ func TestIntegration_StartTaskTestAuthorization(t *testing.T) {
 	assert.Equal(t, resp.TaskId, adminStatusResp.TaskId)
 	assert.NotNil(t, adminStatusResp.ExitCode)
 	assert.Equal(t, int32(0), *adminStatusResp.ExitCode)
+
 }

--- a/tests/integration/main_test.go
+++ b/tests/integration/main_test.go
@@ -48,8 +48,10 @@ func TestMain(m *testing.M) {
 // startTestServer starts the test server and returns a function to stop it
 // will only be called once
 func startTestServer() (func(), error) {
-	srv, err := server.New(context.Background(), "localhost:0")
+	ctx, cancel := context.WithCancel(context.Background())
+	srv, err := server.New(ctx, "localhost:0")
 	if err != nil {
+		cancel()
 		return nil, fmt.Errorf("failed to create test server: %w", err)
 	}
 
@@ -60,6 +62,7 @@ func startTestServer() (func(), error) {
 	}()
 
 	stopServer := func() {
+		cancel()
 		srv.Shutdown()
 	}
 

--- a/tests/integration/stream_test.go
+++ b/tests/integration/stream_test.go
@@ -2,6 +2,7 @@ package integration
 
 import (
 	"context"
+	"io"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -31,7 +32,7 @@ func TestIntegration_StreamTaskOutputContextCanceled(t *testing.T) {
 	assert.Equal(t, codes.Canceled, sts.Code())
 }
 
-func TestIntegration_StreamTaskOutput(t *testing.T) {
+func TestIntegration_ShCommandOutput(t *testing.T) {
 	t.Parallel()
 
 	client := createTestClient(t, "client001")
@@ -39,15 +40,71 @@ func TestIntegration_StreamTaskOutput(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 	defer cancel()
 
+	// Start a task that runs a sh command that prints three lines ex:
+	//   Line 1
+	//   Line 2
+	//   Line 3
+	startResp, err := client.StartTask(ctx, &pb.StartTaskRequest{
+		Command: "sh",
+		Args:    []string{"-c", "for i in $(seq 1 3); do echo \"Line $i\"; done"},
+	})
+
+	require.NoError(t, err)
+	require.NotEmpty(t, startResp.TaskId)
+
 	stream, err := client.StreamTaskOutput(ctx, &pb.StreamTaskOutputRequest{
-		TaskId: "375b0522-72ed-4f3f-88d0-01d360d06b8c",
+		TaskId: startResp.TaskId,
 	})
 	require.NoError(t, err)
 
-	resp, err := stream.Recv()
-	assert.Nil(t, resp)
-	require.Error(t, err)
-	sts, ok := status.FromError(err)
-	require.True(t, ok)
-	assert.Equal(t, codes.Unimplemented, sts.Code())
+	var allOutput []byte
+	for {
+		resp, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		require.NoError(t, err)
+		allOutput = append(allOutput, resp.Output...)
+	}
+
+	// The expected output is exactly as printed by the sh command.
+	expectedOutput := "Line 1\nLine 2\nLine 3\n"
+	assert.Equal(t, expectedOutput, string(allOutput))
+}
+
+func TestIntegration_StreamTaskOutput_StdoutStderr(t *testing.T) {
+	t.Parallel()
+
+	client := createTestClient(t, "client001")
+
+	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
+	defer cancel()
+
+	startResp, err := client.StartTask(ctx, &pb.StartTaskRequest{
+		Command: "sh",
+		Args:    []string{"-c", `echo "Hello, stdout"; echo "Hello, stderr" >&2`},
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, startResp.TaskId)
+
+	stream, err := client.StreamTaskOutput(ctx, &pb.StreamTaskOutputRequest{
+		TaskId: startResp.TaskId,
+	})
+	require.NoError(t, err)
+
+	var allOutput []byte
+	for {
+		resp, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		require.NoError(t, err)
+		allOutput = append(allOutput, resp.Output...)
+	}
+
+	outputStr := string(allOutput)
+
+	// Verify that the output includes both expected messages
+	assert.Contains(t, outputStr, "Hello, stdout", "expected stdout output missing")
+	assert.Contains(t, outputStr, "Hello, stderr", "expected stderr output missing")
 }

--- a/tests/integration/stream_test.go
+++ b/tests/integration/stream_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -13,6 +14,8 @@ import (
 
 	pb "github.com/mikewurtz/taskman/gen/proto"
 )
+
+const streamTestTimeout = 10 * time.Second
 
 func TestIntegration_StreamTaskOutputContextCanceled(t *testing.T) {
 	t.Parallel()
@@ -38,7 +41,7 @@ func TestIntegration_ShCommandOutput(t *testing.T) {
 
 	client := createTestClient(t, "client001")
 
-	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), streamTestTimeout)
 	defer cancel()
 
 	// Start a task that runs a sh command that prints three lines ex:
@@ -78,7 +81,7 @@ func TestIntegration_StreamTaskOutput_StdoutStderr(t *testing.T) {
 
 	client := createTestClient(t, "client001")
 
-	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), streamTestTimeout)
 	defer cancel()
 
 	startResp, err := client.StartTask(ctx, &pb.StartTaskRequest{
@@ -115,7 +118,7 @@ func TestIntegration_ConcurrentStreamTaskOutput(t *testing.T) {
 
 	client1 := createTestClient(t, "client001")
 
-	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), streamTestTimeout)
 	defer cancel()
 
 	startResp, err := client1.StartTask(ctx, &pb.StartTaskRequest{


### PR DESCRIPTION
This update adds support for streaming task output (stdout and stderr) via a new StreamTaskOutput API.

Summary
- Introduced a TaskWriter component that buffers combined stdout/stderr output from each task.
- Each connected client maintains a read offset into the shared output buffer and receives data in real time.
- Streaming is designed to support multiple concurrent clients. A slow client will not block others.
- Added integration tests to validate stream behavior, including full task output, mixed stdout/stderr, and client-side cancellations.

Additional Changes
- Introduced a timeout around grpcServer.GracefulStop() to avoid indefinite blocking during shutdown, particularly when long-lived streaming RPCs are active.